### PR TITLE
Configure Flask secret key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ pip3 install -r requirements.txt
 
 # Edit RDS credentials in app.py
 nano app.py
+
+# Set Flask secret key (defaults to "change-me" if unset)
+export SECRET_KEY="your-secret-key"
 ```
 
 ## Running the App

--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ from flask import Flask, render_template, request, redirect
 import pymysql
 
 app = Flask(__name__)
+import os
+app.secret_key = os.environ.get("SECRET_KEY", "change-me")
 
 # Update with your RDS DB details
 DB_HOST = "your-rds-endpoint"


### PR DESCRIPTION
## Summary
- load SECRET_KEY from environment with fallback default
- document SECRET_KEY usage in deployment instructions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6ca278294832da7fdc299168e4835