### PR TITLE
Use environment variables for database configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,11 @@ EXPOSE 5000
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
 
+# Database connection parameters (override at runtime)
+ENV DB_HOST=""
+ENV DB_USER=""
+ENV DB_PASS=""
+ENV DB_NAME=""
+
 # Run the Flask app
 CMD ["flask", "run"]

--- a/README.md
+++ b/README.md
@@ -61,11 +61,16 @@ cd <your-repo>
 # Install dependencies
 pip3 install -r requirements.txt
 
-# Edit RDS credentials in app.py
-nano app.py
+# Set database credentials
+export DB_HOST="your-rds-endpoint"
+export DB_USER="admin"
+export DB_PASS="yourpassword"
+export DB_NAME="mydb"
 ```
 
 ## Running the App
+
+Ensure `DB_HOST`, `DB_USER`, `DB_PASS`, and `DB_NAME` are set in your shell or stored in a `.env` file before launching.
 
 ```bash
 # Foreground
@@ -81,11 +86,12 @@ Visit `http://<EC2_PUBLIC_IP>:5000` in your browser.
 
 ## Example DB Configuration
 
-```python
-DB_HOST = "your-rds-endpoint"
-DB_USER = "admin"
-DB_PASS = "yourpassword"
-DB_NAME = "mydb"
+```bash
+# .env or shell exports
+DB_HOST="your-rds-endpoint"
+DB_USER="admin"
+DB_PASS="yourpassword"
+DB_NAME="mydb"
 ```
 
 ## Docker (optional)
@@ -96,5 +102,16 @@ Build a multi-stage image:
 docker build -t multibuildflask \
   -f multistagedocker/Dockerfile \
   .
+```
+
+Run the container with database variables:
+
+```bash
+docker run -p 5000:5000 \
+  -e DB_HOST="your-rds-endpoint" \
+  -e DB_USER="admin" \
+  -e DB_PASS="yourpassword" \
+  -e DB_NAME="mydb" \
+  multibuildflask
 ```
 

--- a/app.py
+++ b/app.py
@@ -1,13 +1,14 @@
 from flask import Flask, render_template, request, redirect
+import os
 import pymysql
 
 app = Flask(__name__)
 
 # Update with your RDS DB details
-DB_HOST = "your-rds-endpoint"
-DB_USER = "admin"
-DB_PASS = "yourpassword"
-DB_NAME = "mydb"
+DB_HOST = os.getenv("DB_HOST")
+DB_USER = os.getenv("DB_USER")
+DB_PASS = os.getenv("DB_PASS")
+DB_NAME = os.getenv("DB_NAME")
 
 def get_connection():
     return pymysql.connect(

--- a/multistagedocker/Dockerfile
+++ b/multistagedocker/Dockerfile
@@ -21,4 +21,10 @@ EXPOSE 5000
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
 
+# Database connection parameters (override at runtime)
+ENV DB_HOST=""
+ENV DB_USER=""
+ENV DB_PASS=""
+ENV DB_NAME=""
+
 CMD ["flask", "run"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -172,9 +172,10 @@ resource "aws_instance" "flask" {
               git clone ${var.git_repo} app
               cd app
               pip3 install -r requirements.txt
-              sed -i 's|your-rds-endpoint|${aws_db_instance.mysql.address}|' app.py
-              sed -i 's|admin|${var.db_username}|' app.py
-              sed -i 's|yourpassword|${var.db_password}|' app.py
+              export DB_HOST=${aws_db_instance.mysql.address}
+              export DB_USER=${var.db_username}
+              export DB_PASS=${var.db_password}
+              export DB_NAME=mydb
               nohup python3 app.py &
               EOT
 


### PR DESCRIPTION
## Summary
- load DB credentials from environment variables in app
- document setting DB_* variables and how to run with Docker
- pass DB settings via Docker and Terraform

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6ca27d158832d8ea29d7140fc55c8