### PR TITLE
Pin Flask dependencies and correct SQLAlchemy package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask
-Flask_SQLAlchemy
-pymysql
+Flask==3.1.2
+Flask-SQLAlchemy==3.1.1
+pymysql==1.1.1
 # Add other dependencies as needed, e.g.:
 # psycopg2-binary
 # mysqlclient


### PR DESCRIPTION
## Summary
- fix Flask-SQLAlchemy package name in requirements
- pin dependency versions for reproducible installs

## Testing
- `pip3 install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a6ca2ae978832dbe6cb53d32a8dbef